### PR TITLE
Pin to a hash instead of latest to allow cache-aware releases

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -46,7 +46,6 @@ impl Cli {
         let output = command.output().expect("Failed to execute docker command");
 
         assert!(output.status.success(), "failed to start container");
-
         let container_id = String::from_utf8(output.stdout)
             .expect("output is not valid utf8")
             .trim()

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -45,7 +45,12 @@ impl Cli {
 
         let output = command.output().expect("Failed to execute docker command");
 
-        assert!(output.status.success(), "failed to start container");
+        assert!(
+            output.status.success(),
+            "failed to start container: {:?}",
+            output
+        );
+
         let container_id = String::from_utf8(output.stdout)
             .expect("output is not valid utf8")
             .trim()

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -45,11 +45,7 @@ impl Cli {
 
         let output = command.output().expect("Failed to execute docker command");
 
-        assert!(
-            output.status.success(),
-            "failed to start container: {:?}",
-            output
-        );
+        assert!(output.status.success(), "failed to start container");
 
         let container_id = String::from_utf8(output.stdout)
             .expect("output is not valid utf8")

--- a/src/images/fake_gcs_server.rs
+++ b/src/images/fake_gcs_server.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image, ImageArgs};
 
-const NAME: &str = "mpgarate/fake-gcs-server";
-const TAG: &str = "latest";
+const NAME: &str = "yottabytt/fake-gcs-server";
+const TAG: &str = "853c4397132f";
 
 #[derive(Debug, Clone)]
 pub struct CloudStorageArgs {

--- a/src/images/fake_gcs_server.rs
+++ b/src/images/fake_gcs_server.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "yottabytt/fake-gcs-server";
-const TAG: &str = "853c4397132f6c594fc9ef379395d8b64b5e8618a88a763743e168b78f0fde1f";
+const TAG: &str = "10e9c4c";
 
 #[derive(Debug, Clone)]
 pub struct CloudStorageArgs {

--- a/src/images/fake_gcs_server.rs
+++ b/src/images/fake_gcs_server.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "yottabytt/fake-gcs-server";
-const TAG: &str = "853c4397132f";
+const TAG: &str = "853c4397132f6c594fc9ef379395d8b64b5e8618a88a763743e168b78f0fde1f";
 
 #[derive(Debug, Clone)]
 pub struct CloudStorageArgs {

--- a/src/images/fake_gcs_server.rs
+++ b/src/images/fake_gcs_server.rs
@@ -1,6 +1,6 @@
 use crate::{core::WaitFor, Image, ImageArgs};
 
-const NAME: &str = "yottabytt/fake-gcs-server";
+const NAME: &str = "mpgarate/fake-gcs-server";
 const TAG: &str = "latest";
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
With the `latest` tag, docker clients may miss an image update, leading to test failures for tests that rely on new functionality. Using the hash forces those caches to read the new image.